### PR TITLE
Added onElementChange to the FormGenerator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@spotoninc/react-form-builder",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spotoninc/react-form-builder",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "A complete form builder for react.",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/form-elements/custom-element.jsx
+++ b/src/form-elements/custom-element.jsx
@@ -11,7 +11,7 @@ class CustomElement extends Component {
 
   render() {
     const { bare } = this.props.data;
-    const props = {};
+    const props = { ...this.props };
     props.name = this.props.data.field_name;
     props.defaultValue = this.props.defaultValue;
 

--- a/src/form.jsx
+++ b/src/form.jsx
@@ -28,6 +28,7 @@ class ReactForm extends React.Component {
     this.answerData = this._convert(props.answer_data);
     this.emitter = new EventEmitter();
     this.getDataById = this.getDataById.bind(this);
+    this.handleChange = this.handleChange.bind(this);
   }
 
   _convert(answers) {
@@ -187,6 +188,13 @@ class ReactForm extends React.Component {
         $input_sig.value = base64;
       }
     }
+  }
+
+  handleChange(data) {
+    const formData = this._collectFormData(this.props.data);
+
+    // eslint-disable-next-line no-unused-expressions
+    this.props.onElementChange?.(formData, data);
   }
 
   handleSubmit(e) {
@@ -362,6 +370,7 @@ class ReactForm extends React.Component {
     const formTokenStyle = {
       display: 'none',
     };
+    console.log('---;', this.handleChange);
     return (
       <div>
           <FormValidator emitter={this.emitter} />

--- a/src/form.jsx
+++ b/src/form.jsx
@@ -370,7 +370,7 @@ class ReactForm extends React.Component {
     const formTokenStyle = {
       display: 'none',
     };
-    console.log('---;', this.handleChange);
+
     return (
       <div>
           <FormValidator emitter={this.emitter} />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -160,6 +160,7 @@ export interface FormGeneratorProps {
   form_method?: string;
   action_name?: string;
   onSubmit?: (info: FormGeneratorOnSubmitParams[]) => void;
+  onElementChange?: (info: FormGeneratorOnSubmitParams[], data?: any) => void;
   data: any[];
   back_action?: string;
   back_name?: string;


### PR DESCRIPTION
Ticket: https://spotonteam.atlassian.net/browse/SAL-5334

**Description**:

FormGenerator already passed `handleChange` to every Custom component but for some reason, `handleChange` didn't exist in the `FormGenerator` at all.

I created the `handleChange` handler, it will collect form data (like it happening on submit) and passed to the new `onElementChange` function, which will come to the `FormGenerator` as a prop. Also `handleChange` accepts the second argument  - `data`, I added it just in case, maybe later we need to pass some additional data from the component to the `FormGenerator`.

Also despite the `Custom Element` wrapper accepting any props, in the render method, it reorganize props in some way and all additional props are missing, so I add the next fix:
```
const props = { ...this.props };
...
```
So after my changes, we will be able to fire `handleChange` in every Custom element whenever it is needed and FormGenerator will receive the latest form data on every change.

**Loom:**
https://www.loom.com/share/989c8b7dc5244f81b1c3c23e847fed77
